### PR TITLE
Add function hpack_strevent() to have human readable event in callback

### DIFF
--- a/inc/hpack.h.in
+++ b/inc/hpack.h.in
@@ -85,6 +85,8 @@ enum hpack_event_e {
 typedef void hpack_event_f(enum hpack_event_e, const char *, size_t,
     void *);
 
+const char * hpack_event_id(enum hpack_event_e);
+
 /* hpack_decode */
 
 struct hpack_decoding {

--- a/lib/cashpack.map
+++ b/lib/cashpack.map
@@ -41,6 +41,7 @@ CASHPACK_0.4 {
     hpack_skip;
     hpack_static;
     hpack_strerror;
+    hpack_event_id;
     hpack_tables;
     hpack_trim;
 

--- a/lib/hpack.c
+++ b/lib/hpack.c
@@ -446,6 +446,18 @@ hpack_strerror(enum hpack_result_e res)
 	return (NULL);
 }
 
+const char *
+hpack_event_id(enum hpack_event_e evt)
+{
+
+#define HPE(val, cod, txt, rst)	\
+	if (evt == cod)		\
+		return (#val);
+#include "tbl/hpack_tbl.h"
+#undef HPE
+	return (NULL);
+}
+
 static void /* NB: hexdump -C output */
 hpack_hexdump(const void *ptr, size_t len, hpack_dump_f *dump, void *priv)
 {

--- a/tst/hpack_arg.c
+++ b/tst/hpack_arg.c
@@ -66,6 +66,11 @@
 		(void)res;					\
 	} while (0)
 
+#define CHECK_EVTID(evt) \
+	do {							\
+		const char *str = hpack_event_id(HPACK_EVT_##evt);			\
+		assert(!strcmp(str, #evt));			\
+	} while (0)
 /**********************************************************************
  * Data structures
  */
@@ -838,6 +843,24 @@ test_dump_unknown(void)
 	hpack_free(&hp);
 }
 
+
+static void
+test_event_id(void)
+{
+	const char *str;
+
+    CHECK_EVTID(FIELD);
+    CHECK_EVTID(NEVER);
+    CHECK_EVTID(INDEX);
+    CHECK_EVTID(NAME);
+    CHECK_EVTID(VALUE);
+    CHECK_EVTID(DATA);
+    CHECK_EVTID(EVICT);
+    CHECK_EVTID(TABLE);
+
+	CHECK_NULL(str, hpack_event_id, UINT16_MAX);
+}
+
 /**********************************************************************
  */
 
@@ -902,6 +925,8 @@ main(void)
 
 	test_strerror();
 	test_dump_unknown();
+
+	test_event_id();
 
 	return (0);
 }


### PR DESCRIPTION
Add function hpack_strevent() to have human readable event in callback.

Example code:
```
void callback(enum hpack_event_e evt, const char *buf, size_t size, void *priv) {
    printf("[%s]\n", hpack_strevent(evt));
}
```