### PR TITLE
Feature/recover

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -10,12 +10,6 @@ test -n "$ROOT_DIR"
 test "${LGTM_WORKSPACE:+set}" = set &&
 sed -i '/CASHPACK_ARG_ENABLE..docs/d' configure.ac
 
-if ! command -v libtoolize >/dev/null 2>&1
-then
-	echo 'libtoolize: command not found, falling back to glibtoolize' >&2
-	alias libtoolize=glibtoolize
-fi
-
 autoreconf -i "$ROOT_DIR"
 
 test "${LGTM_WORKSPACE:+set}" = set && exit

--- a/inc/hpack.h.in
+++ b/inc/hpack.h.in
@@ -97,6 +97,8 @@ enum hpack_event_e {
 typedef void hpack_event_f(enum hpack_event_e, const char *, size_t,
     void *);
 
+const char * hpack_event_id(enum hpack_event_e);
+
 /* hpack_decode */
 
 struct hpack_decoding {

--- a/inc/hpack.h.in
+++ b/inc/hpack.h.in
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2017 Dridi Boukelmoune
+ * Copyright (c) 2016-2020 Dridi Boukelmoune
  * All rights reserved.
  *
  * Author: Dridi Boukelmoune <dridi.boukelmoune@gmail.com>

--- a/inc/hpack.h.in
+++ b/inc/hpack.h.in
@@ -59,8 +59,8 @@ struct hpack_alloc {
 
 extern const struct hpack_alloc *hpack_default_alloc;
 
-struct hpack * hpack_decoder(size_t, ssize_t, const struct hpack_alloc *);
-struct hpack * hpack_encoder(size_t, ssize_t, const struct hpack_alloc *);
+struct hpack * hpack_decoder(size_t, ssize_t, const struct hpack_alloc *, uint32_t);
+struct hpack * hpack_encoder(size_t, ssize_t, const struct hpack_alloc *, uint32_t);
 void hpack_free(struct hpack **);
 
 enum hpack_result_e hpack_resize(struct hpack **, size_t);

--- a/inc/hpack.h.in
+++ b/inc/hpack.h.in
@@ -78,6 +78,9 @@ enum hpack_result_e hpack_trim(struct hpack **);
 
 /* hpack_error */
 
+extern const char *hpack_unknown_name;
+extern const char *hpack_unknown_value;
+
 typedef void hpack_dump_f(void *, const char *, ...);
 
 const char * hpack_strerror(enum hpack_result_e);

--- a/inc/hpack.h.in
+++ b/inc/hpack.h.in
@@ -34,6 +34,15 @@
 #  include <unistd.h>
 #endif
 
+/* hpack_config */
+
+enum hpack_config_e {
+#define HPC(f, v, l) \
+	HPACK_CFG_##f	= v,
+#include "tbl/hpack_tbl.h"
+#undef HPC
+};
+
 /* hpack_result */
 
 enum hpack_result_e {

--- a/inc/hpack_priv.h
+++ b/inc/hpack_priv.h
@@ -197,6 +197,7 @@ struct hpack {
 #define ENCODER_MAGIC		0x8ab1fb4c
 #define DECODER_MAGIC		0xab0e3218
 #define DEFUNCT_MAGIC		0xdffadae9
+	uint32_t		flags;
 	struct hpack_alloc	alloc;
 	struct hpack_size	sz;
 	struct hpack_state	state;

--- a/inc/hpack_priv.h
+++ b/inc/hpack_priv.h
@@ -36,6 +36,9 @@
 #define HPACK_LIMIT(hp) \
 	(((hp)->sz.lim >= 0 ? (size_t)(hp)->sz.lim : (hp)->sz.max))
 
+#define HPC_DEGRADED() \
+    (ctx->hp->flags & HPACK_CFG_DEGRADED)
+
 #define CALL(func, ...)					\
 	do {						\
 		if ((func)(__VA_ARGS__) != 0)		\

--- a/inc/tbl/hpack_tbl.h
+++ b/inc/tbl/hpack_tbl.h
@@ -183,6 +183,17 @@ HPE(TABLE, 7, "the table was updated",
 	"\tA decoder or an encoder sends a TABLE event when a dynamic table\n"
 	"\tupdate is decoded or encoded. The *buf* argument is always\n"
 	"\t``NULL`` and *len* is the new table maximum size.\n\n")
+
+HPE(PTR, 8, "header line pointer",
+    "\tA decoder sends a PTR event containing the address pointer of the\n"
+    "\tstart byte of a header line.\n"
+    "\tThis event will be emitted only when ``HPACK_CFG_SEND_PTR`` is set.\n\n")
+
+HPE(RECERR, 9, "recoverable error",
+    "\tA decoder sends a RECERR event containing the address pointer of\n"
+    "\tthe byte in error, which may be in the middle of a header line.\n"
+    "\tThis event will be emitted only when ``HPACK_CFG_SEND_ERR`` is set.\n\n")
+
 #endif /* HPE */
 
 #ifdef HPF
@@ -233,7 +244,24 @@ HPF(AUT_IDX, 0x80,
 #ifdef HPC
 /* configuration flags */
 HPC(DEGRADED, 0x01,
-    "\tTODO: write documentation.\n\n")
+    "\tDegraded mode tries to recover from missing indexes in the dynamic\n"
+    "\ttable. A missing header name will be replaced by ``unknown_name``,\n"
+    "\tand a missing value will be replaced by ``unknown_value``.\n"
+    "\t\n\n")
+
+HPC(SEND_PTR, 0x02,
+    "\tSends a ``PTR`` event at the start of every header line.\n"
+    "\tThe address of the header line in the header block will be placed\n"
+    "\tin the ``const char *buf`` parameter of the callback.\n\n")
+
+HPC(SEND_ERR, 0x04,
+    "\tSends a ``RECERR`` event whenever a recoverable error occurs.\n"
+    "\tThe address of the error in the header block will be placed\n"
+    "\tin the ``const char *buf`` parameter of the callback.\n"
+    "\tThis parameter can be used with the ``SEND_PTR`` parameter\n"
+    "\tto be able to spot and/or extract errored header lines from\n"
+    "\ta header block.\n"
+    "\tNote: this is mostly useful in ``DEGRADED`` mode.\n\n")
 
 #endif /* HPC */
 

--- a/inc/tbl/hpack_tbl.h
+++ b/inc/tbl/hpack_tbl.h
@@ -227,7 +227,15 @@ HPF(AUT_IDX, 0x80,
 	"\tname and value) is found, either ``TYP_DYN`` or ``TYP_LIT`` are\n"
 	"\tturned into ``TYP_IDX``. If a match is found, *idx* or *nam_idx*\n"
 	"\tis set to non-zero, zero otherwise.\n\n")
+
 #endif /* HPF */
+
+#ifdef HPC
+/* configuration flags */
+HPC(DEGRADED, 0x01,
+    "\tTODO: write documentation.\n\n")
+
+#endif /* HPC */
 
 #ifdef HPP
 HPP(STR, 7, 0x00) /* Section 5.2 */

--- a/lib/cashpack.map
+++ b/lib/cashpack.map
@@ -41,6 +41,7 @@ CASHPACK_0.4 {
     hpack_skip;
     hpack_static;
     hpack_strerror;
+    hpack_event_id;
     hpack_tables;
     hpack_trim;
 

--- a/lib/cashpack.map
+++ b/lib/cashpack.map
@@ -46,6 +46,8 @@ CASHPACK_0.4 {
 
     # variables
     hpack_default_alloc;
+    hpack_unknown_name;
+    hpack_unknown_value;
 
   local:
     *;

--- a/lib/hpack.c
+++ b/lib/hpack.c
@@ -625,7 +625,9 @@ hpack_decode_field(HPACK_CTX)
 		else
 			CALL(HPT_decode_name, ctx);
 		assert(ctx->buf > ctx->fld.nam);
-		ctx->fld.nam_sz = (size_t)(ctx->buf - ctx->fld.nam - 1);
+        if(ctx->fld.nam != hpack_unknown_name) {
+            ctx->fld.nam_sz = (size_t)(ctx->buf - ctx->fld.nam - 1);
+        }
 		CALL(HPV_token, ctx, ctx->fld.nam, ctx->fld.nam_sz);
 		ctx->fld.val = ctx->buf;
 		ctx->hp->state.stp = HPACK_STP_VAL_LEN;

--- a/lib/hpack.c
+++ b/lib/hpack.c
@@ -432,6 +432,22 @@ hpack_entry(struct hpack *hp, size_t idx, const char **nam, const char **val)
 }
 
 /**********************************************************************
+ * Events
+ */
+
+const char *
+hpack_event_id(enum hpack_event_e evt)
+{
+
+#define HPE(val, cod, txt, rst)	\
+	if (evt == cod)		\
+		return (#val);
+#include "tbl/hpack_tbl.h"
+#undef HPE
+	return (NULL);
+}
+
+/**********************************************************************
  * Errors
  */
 

--- a/lib/hpack.c
+++ b/lib/hpack.c
@@ -88,7 +88,7 @@ const struct hpack_alloc *hpack_default_alloc = &hpack_libc_alloc;
 
 static struct hpack *
 hpack_new(uint32_t magic, size_t mem, size_t max,
-    const struct hpack_alloc *ha)
+    const struct hpack_alloc *ha, uint32_t flags)
 {
 	struct hpack *hp;
 
@@ -104,6 +104,7 @@ hpack_new(uint32_t magic, size_t mem, size_t max,
 
 	(void)memset(hp, 0, sizeof *hp);
 	hp->magic = magic;
+	hp->flags = flags;
 	hp->ctx.hp = hp;
 	(void)memcpy(&hp->alloc, ha, sizeof *ha);
 	hp->sz.mem = mem;
@@ -116,14 +117,14 @@ hpack_new(uint32_t magic, size_t mem, size_t max,
 }
 
 struct hpack *
-hpack_encoder(size_t max, ssize_t lim, const struct hpack_alloc *ha)
+hpack_encoder(size_t max, ssize_t lim, const struct hpack_alloc *ha, uint32_t flags)
 {
 	enum hpack_result_e res;
 	struct hpack *hp, *tmp;
 	size_t mem;
 
 	mem = lim >= 0 ? (size_t)lim : max;
-	hp = hpack_new(ENCODER_MAGIC, mem, max, ha);
+	hp = hpack_new(ENCODER_MAGIC, mem, max, ha, flags);
 	if (lim >= 0 && hp != NULL) {
 		tmp = hp;
 		res = hpack_limit(&tmp, (size_t)lim);
@@ -136,14 +137,14 @@ hpack_encoder(size_t max, ssize_t lim, const struct hpack_alloc *ha)
 }
 
 struct hpack *
-hpack_decoder(size_t max, ssize_t rsz, const struct hpack_alloc *ha)
+hpack_decoder(size_t max, ssize_t rsz, const struct hpack_alloc *ha, uint32_t flags)
 {
 	size_t mem;
 
 	mem = rsz >= 0 ? (size_t)rsz : max;
 	if (mem < max)
 		mem = max;
-	return (hpack_new(DECODER_MAGIC, mem, max, ha));
+	return (hpack_new(DECODER_MAGIC, mem, max, ha, flags));
 }
 
 static enum hpack_result_e

--- a/lib/hpack.c
+++ b/lib/hpack.c
@@ -772,6 +772,8 @@ hpack_decode(struct hpack *hp, const struct hpack_decoding *dec)
 	ctx->res = dec->cut ? HPACK_RES_BLK : HPACK_RES_OK;
 
 	while (ctx->ptr_len > 0) {
+        if(ctx->hp->flags & HPACK_CFG_SEND_PTR)
+            HPC_notify(ctx, HPACK_EVT_PTR, ctx->ptr.blk, 0);
 		if (!hp->state.bsy && hp->state.stp == HPACK_STP_FLD_INT)
 			hp->state.typ = *ctx->ptr.blk;
 		if ((hp->state.typ & HPACK_PAT_UPD) != HPACK_PAT_UPD) {
@@ -842,6 +844,13 @@ hpack_assert_cb(enum hpack_event_e evt, const char *buf, size_t len, void *priv)
 		assert(buf != NULL);
 		assert(len == strlen(buf));
 		break;
+    case HPACK_EVT_PTR:
+		assert(buf != NULL);
+        break;
+    case HPACK_EVT_RECERR:
+		assert(buf != NULL);
+		assert(len > 0);
+        break;
 	case HPACK_EVT_DATA:
 		WRONG("Invalid event");
 	default:

--- a/lib/hpack_tbl.c
+++ b/lib/hpack_tbl.c
@@ -115,6 +115,8 @@ HPT_field(HPACK_CTX, size_t idx, struct hpt_field *hf)
         while(idx >= ctx->hp->cnt) {
             HPT_index(ctx);
         }
+        if(ctx->hp->flags & HPACK_CFG_SEND_ERR)
+            HPC_notify(ctx, HPACK_EVT_RECERR, ctx->ptr.blk, idx);
     }
 	EXPECT(ctx, IDX, idx <= ctx->hp->cnt);
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -61,6 +61,7 @@ dist_man_MANS = \
 	hpack_decode.3 \
 	hpack_encode.3 \
 	hpack_error.3 \
+	hpack_event_id.3 \
 	hpack_index.3 \
 	$(hpack_alloc_links) \
 	$(hpack_decode_links) \

--- a/man/cashdumb.c
+++ b/man/cashdumb.c
@@ -201,7 +201,7 @@ main(void)
 	size_t linelen;
 
 	/* initialization */
-	hp = hpack_encoder(TABLE_SIZE, -1, hpack_default_alloc);
+	hp = hpack_encoder(TABLE_SIZE, -1, hpack_default_alloc, 0);
 	(void)memset(&stt, 0, sizeof stt);
 	stt.fld = static_fld;
 	stt.dmb = static_dmb;

--- a/man/cashdump.c
+++ b/man/cashdump.c
@@ -131,7 +131,7 @@ main(int argc, char **argv)
 
 	/* initialization */
 	first = 1;
-	hp = hpack_decoder(4096, -1, hpack_default_alloc);
+	hp = hpack_decoder(4096, -1, hpack_default_alloc, 0);
 	dec.blk = blk;
 	dec.blk_len = 0;
 	dec.buf = buf;

--- a/man/cashpack.3.rst.in
+++ b/man/cashpack.3.rst.in
@@ -1,4 +1,4 @@
-.. Copyright (c) 2016-2017 Dridi Boukelmoune
+.. Copyright (c) 2016-2020 Dridi Boukelmoune
 .. All rights reserved.
 ..
 .. Redistribution and use in source and binary forms, with or without
@@ -180,6 +180,9 @@ When dealing with events, unknown values should be ignored. Future versions of
 cashpack may introduce new events. The values for existing events shall never
 be changed.
 
+A static textual representation of the event can be obtained with the function
+``hpack_event_id()``.
+
 EXAMPLE
 =======
 
@@ -239,6 +242,7 @@ SEE ALSO
 **hpack_encode**\(3),
 **hpack_encoder**\(3),
 **hpack_entry**\(3),
+**hpack_event_id**\(3),
 **hpack_free**\(3),
 **hpack_limit**\(3),
 **hpack_resize**\(3),

--- a/man/hpack_alloc.3.rst
+++ b/man/hpack_alloc.3.rst
@@ -193,6 +193,7 @@ SEE ALSO
 **hpack_dynamic**\(3),
 **hpack_encode**\(3),
 **hpack_entry**\(3),
+**hpack_event_id**\(3),
 **hpack_search**\(3),
 **hpack_skip**\(3),
 **hpack_static**\(3),

--- a/man/hpack_decode.3.rst
+++ b/man/hpack_decode.3.rst
@@ -301,6 +301,7 @@ SEE ALSO
 **hpack_encode**\(3),
 **hpack_encoder**\(3),
 **hpack_entry**\(3),
+**hpack_event_id**\(3),
 **hpack_free**\(3),
 **hpack_limit**\(3),
 **hpack_resize**\(3),

--- a/man/hpack_dump.c
+++ b/man/hpack_dump.c
@@ -49,7 +49,7 @@ main(void)
 {
 	struct hpack *hp;
 
-	hp = hpack_encoder(4096, -1, hpack_default_alloc);
+	hp = hpack_encoder(4096, -1, hpack_default_alloc, 0);
 	if (hp == NULL)
 		return (EXIT_FAILURE);
 

--- a/man/hpack_encode.3.rst.in
+++ b/man/hpack_encode.3.rst.in
@@ -278,6 +278,7 @@ SEE ALSO
 **hpack_dynamic**\(3),
 **hpack_encoder**\(3),
 **hpack_entry**\(3),
+**hpack_event_id**\(3),
 **hpack_free**\(3),
 **hpack_limit**\(3),
 **hpack_resize**\(3),

--- a/man/hpack_error.3.rst.in
+++ b/man/hpack_error.3.rst.in
@@ -109,6 +109,7 @@ SEE ALSO
 **hpack_encode**\(3),
 **hpack_encoder**\(3),
 **hpack_entry**\(3),
+**hpack_event_id**\(3),
 **hpack_free**\(3),
 **hpack_limit**\(3),
 **hpack_resize**\(3),

--- a/man/hpack_event_id.3.rst
+++ b/man/hpack_event_id.3.rst
@@ -1,0 +1,82 @@
+.. Copyright (c) 2020 Dridi Boukelmoune
+.. All rights reserved.
+..
+.. Redistribution and use in source and binary forms, with or without
+.. modification, are permitted provided that the following conditions
+.. are met:
+.. 1. Redistributions of source code must retain the above copyright
+..    notice, this list of conditions and the following disclaimer.
+.. 2. Redistributions in binary form must reproduce the above copyright
+..    notice, this list of conditions and the following disclaimer in the
+..    documentation and/or other materials provided with the distribution.
+..
+.. THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.. ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.. IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.. ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+.. FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.. DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.. OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.. HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.. LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.. OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.. SUCH DAMAGE.
+
+==============
+hpack_event_id
+==============
+
+---------------------------
+turn an event into a string
+---------------------------
+
+:Manual section: 3
+
+SYNOPSIS
+========
+
+| **#include <stdint.h>**
+| **#include <stdlib.h>**
+| **#include <unistd.h>**
+| **#include <hpack.h>**
+|
+| **enum hpack_event_e;**
+|
+| **const char * hpack_event_id(enum hpack_event_e** *evt*\ **);**
+
+DESCRIPTION
+===========
+
+This is an overview of event functions in cashpack, a stateless event-driven
+HPACK codec written in C.
+
+The ``hpack_event_id()`` function is a thread-safe function that translates an
+event code into a human readable string identifier.
+
+RETURN VALUE
+============
+
+The ``hpack_event_id()`` function returns a constant string corresponding to
+an event enumerator, or ``NULL`` for unknown values.
+
+SEE ALSO
+========
+
+**cashpack**\(3),
+**hpack_decode**\(3),
+**hpack_decode_fields**\(3),
+**hpack_decoder**\(3),
+**hpack_dump**\(3),
+**hpack_dynamic**\(3),
+**hpack_encode**\(3),
+**hpack_encoder**\(3),
+**hpack_entry**\(3),
+**hpack_free**\(3),
+**hpack_limit**\(3),
+**hpack_resize**\(3),
+**hpack_search**\(3),
+**hpack_skip**\(3),
+**hpack_static**\(3),
+**hpack_strerror**\(3),
+**hpack_tables**\(3),
+**hpack_trim**\(3)

--- a/man/hpack_index.3.rst
+++ b/man/hpack_index.3.rst
@@ -156,6 +156,7 @@ SEE ALSO
 **hpack_dump**\(3),
 **hpack_encode**\(3),
 **hpack_encoder**\(3),
+**hpack_event_id**\(3),
 **hpack_free**\(3),
 **hpack_limit**\(3),
 **hpack_resize**\(3),

--- a/tst/fdecode.c
+++ b/tst/fdecode.c
@@ -234,7 +234,7 @@ main(int argc, char **argv)
 
 	ctx.blk = blk;
 
-	hp = hpack_decoder(tbl_sz, -1, hpack_default_alloc);
+	hp = hpack_decoder(tbl_sz, -1, hpack_default_alloc, 0);
 	assert(hp != NULL);
 
 	priv.hp = hp;

--- a/tst/fdecode.c
+++ b/tst/fdecode.c
@@ -123,8 +123,6 @@ resize_table(void *priv, const void *buf, size_t len, unsigned cut)
 	return (hpack_resize(&priv2->hp, len));
 }
 
-struct hpack *hp = NULL;
-
 int
 main(int argc, char **argv)
 {

--- a/tst/hdecode.c
+++ b/tst/hdecode.c
@@ -270,7 +270,7 @@ main(int argc, char **argv)
 
 	ctx.blk = blk;
 
-	hp = hpack_decoder(tbl_sz, -1, hpack_default_alloc);
+	hp = hpack_decoder(tbl_sz, -1, hpack_default_alloc, 0);
 	assert(hp != NULL);
 
 	priv.hp = hp;

--- a/tst/hdecode.c
+++ b/tst/hdecode.c
@@ -158,8 +158,6 @@ resize_table(void *priv, const void *buf, size_t len, unsigned cut)
 	return (hpack_resize(&priv2->hp, len));
 }
 
-struct hpack *hp = NULL;
-
 int
 main(int argc, char **argv)
 {

--- a/tst/hencode.c
+++ b/tst/hencode.c
@@ -343,7 +343,7 @@ main(int argc, char **argv)
 		return (EXIT_FAILURE);
 	}
 
-	hp = hpack_encoder(tbl_sz, tbl_mem, hpack_default_alloc);
+	hp = hpack_encoder(tbl_sz, tbl_mem, hpack_default_alloc, 0);
 	assert(hp != NULL);
 
 	ctx.res = HPACK_RES_OK;

--- a/tst/hencode.c
+++ b/tst/hencode.c
@@ -274,8 +274,6 @@ parse_commands(struct enc_ctx *ctx)
 	return (parse_commands(ctx));
 }
 
-struct hpack *hp = NULL;
-
 int
 main(int argc, char **argv)
 {

--- a/tst/hpack_arg.c
+++ b/tst/hpack_arg.c
@@ -110,7 +110,7 @@ make_decoder(size_t max, ssize_t rsz, const struct hpack_alloc *ha)
 {
 	struct hpack *dec;
 
-	CHECK_NOTNULL(dec, hpack_decoder, max, rsz, ha);
+	CHECK_NOTNULL(dec, hpack_decoder, max, rsz, ha, 0);
 	return (dec);
 }
 
@@ -119,7 +119,7 @@ make_encoder(size_t max, ssize_t lim, const struct hpack_alloc *ha)
 {
 	struct hpack *enc;
 
-	CHECK_NOTNULL(enc, hpack_encoder, max, lim, ha);
+	CHECK_NOTNULL(enc, hpack_encoder, max, lim, ha, 0);
 	return (enc);
 }
 
@@ -244,13 +244,13 @@ static struct hpack_encoding unknown_encoding = {
 static void
 test_null_alloc(void)
 {
-	CHECK_NULL(hp, hpack_decoder, 0, -1, NULL);
+	CHECK_NULL(hp, hpack_decoder, 0, -1, NULL, 0);
 }
 
 static void
 test_null_malloc(void)
 {
-	CHECK_NULL(hp, hpack_decoder, 0, -1, &null_alloc);
+	CHECK_NULL(hp, hpack_decoder, 0, -1, &null_alloc, 0);
 }
 
 static void
@@ -264,25 +264,25 @@ static void
 test_alloc_overflow(void)
 {
 	CHECK_NULL(hp, hpack_decoder, UINT16_MAX + 1, -1,
-	    hpack_default_alloc);
+	    hpack_default_alloc, 0);
 	CHECK_NULL(hp, hpack_decoder, 4096, UINT16_MAX + 1,
-	    hpack_default_alloc);
+	    hpack_default_alloc, 0);
 }
 
 static void
 test_alloc_underflow(void)
 {
-	CHECK_NOTNULL(hp, hpack_decoder, 4096, 2048, hpack_default_alloc);
+	CHECK_NOTNULL(hp, hpack_decoder, 4096, 2048, hpack_default_alloc, 0);
 	hpack_free(&hp);
-	CHECK_NOTNULL(hp, hpack_encoder, 4096, 2048, hpack_default_alloc);
+	CHECK_NOTNULL(hp, hpack_encoder, 4096, 2048, hpack_default_alloc, 0);
 	hpack_free(&hp);
 }
 
 static void
 test_malloc_failure(void)
 {
-	CHECK_NULL(hp, hpack_decoder, 4096, -1, &static_alloc);
-	CHECK_NULL(hp, hpack_encoder, 0,  4096, &static_alloc);
+	CHECK_NULL(hp, hpack_decoder, 4096, -1, &static_alloc, 0);
+	CHECK_NULL(hp, hpack_encoder, 0,  4096, &static_alloc, 0);
 }
 
 static void

--- a/tst/hpack_arg.c
+++ b/tst/hpack_arg.c
@@ -838,6 +838,18 @@ test_dump_unknown(void)
 	hpack_free(&hp);
 }
 
+static void
+test_event_id(void)
+{
+	const char *str;
+
+#define HPE(e, v, d, l)						\
+	CHECK_NOTNULL(str, hpack_event_id, HPACK_EVT_ ## e);
+#include "tbl/hpack_tbl.h"
+#undef HPE
+	CHECK_NULL(str, hpack_event_id, UINT16_MAX);
+}
+
 /**********************************************************************
  */
 
@@ -902,6 +914,8 @@ main(void)
 
 	test_strerror();
 	test_dump_unknown();
+
+	test_event_id();
 
 	return (0);
 }

--- a/tst/hpack_mbm.c
+++ b/tst/hpack_mbm.c
@@ -122,7 +122,7 @@ mbm_setup(void)
 	struct hpack_encoding he;
 	char buf[64];
 
-	hp = hpack_encoder(4096, -1, hpack_default_alloc);
+	hp = hpack_encoder(4096, -1, hpack_default_alloc, 0);
 	if (hp == NULL)
 		WRONG("hpack_encoder");
 

--- a/tst/ngdecode.c
+++ b/tst/ngdecode.c
@@ -45,8 +45,6 @@
 
 #include "tst.h"
 
-struct hpack *hp = NULL; /* unused, but needed by tst.c */
-
 static int
 print_headers(void *priv, const void *buf, size_t len)
 {


### PR DESCRIPTION
Added the ability to force decoding if an index is unknown in the dynamic table.

This is enabled with the flag HPACK_CFG_DEGRADED passed to hpack_decoder().

Note: This needs more testing, and code coverage and documentation are not done yet.